### PR TITLE
Fixes data relation data validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,27 +31,29 @@ for another charm that requires this interface.
 
 ```python
 
+from ipaddress import AddressValueError
+
+from charms.lte_core_interface.v0.lte_core_interface import LTECoreProvides
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
-
-from charms.lte_core_interface.v0.lte_core_interface import (
-    LTECoreProvides,
-)
+from ops.model import BlockedStatus
 
 
 class DummyLTECoreProviderCharm(CharmBase):
     def __init__(self, *args):
+        """Charm the service."""
         super().__init__(*args)
         self.lte_core_provider = LTECoreProvides(self, "lte-core")
-        self.framework.observe(
-            self.on.lte_core_relation_joined, self._on_lte_core_relation_joined
-        )
+        self.framework.observe(self.on.lte_core_relation_joined, self._on_lte_core_relation_joined)
 
     def _on_lte_core_relation_joined(self, event: RelationJoinedEvent) -> None:
         if not self.unit.is_leader():
             return
-        mme_ipv4_address = "some code for fetching the mme ipv4 address"
-        self.lte_core_provider.set_lte_core_information(mme_ipv4_address=mme_ipv4_address)
+        mme_ipv4_address = "<Here goes your code for fetching the MME IPv4 address>"
+        try:
+            self.lte_core_provider.set_lte_core_information(mme_ipv4_address=mme_ipv4_address)
+        except AddressValueError:
+            self.unit.status = BlockedStatus("Invalid MME IPv4 address.")
 
 
 if __name__ == "__main__":
@@ -87,7 +89,7 @@ class DummyLTECoreRequirerCharm(CharmBase):
 
     def _on_lte_core_available(self, event: LTECoreAvailableEvent):
         mme_ipv4_address = event.mme_ipv4_address
-        <Do something with the mme_ipv4_address>
+        # Do something with the mme_ipv4_address
 
 
 if __name__ == "__main__":

--- a/lib/charms/lte_core_interface/v0/lte_core_interface.py
+++ b/lib/charms/lte_core_interface/v0/lte_core_interface.py
@@ -81,8 +81,11 @@ class DummyLTECoreProviderCharm(CharmBase):
     def _on_lte_core_relation_joined(self, event: RelationJoinedEvent) -> None:
         if not self.unit.is_leader():
             return
-        mme_ipv4_address = "some code for fetching the mme ipv4 address"
-        self.lte_core_provider.set_lte_core_information(mme_ipv4_address=mme_ipv4_address)
+        mme_ipv4_address = "<Here goes your code for fetching the MME IPv4 address>"
+        try:
+            self.lte_core_provider.set_lte_core_information(mme_ipv4_address=mme_ipv4_address)
+        except AddressValueError:
+            self.unit.status = BlockedStatus("Invalid MME IPv4 address.")
 
 
 if __name__ == "__main__":
@@ -97,7 +100,6 @@ from ipaddress import AddressValueError, IPv4Address
 from jsonschema import exceptions, validate  # type: ignore[import]
 from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Handle, Object
-from ops.model import BlockedStatus
 
 # The unique Charmhub library identifier, never change it
 LIBID = "3fbbdca922ec4ddd9598c3382034ad61"
@@ -236,7 +238,6 @@ class LTECoreProvides(Object):
         if not self.model.get_relation(self.relationship_name):
             raise RuntimeError(f"Relation {self.relationship_name} not created yet.")
         if not self._mme_ipv4_address_is_valid(mme_ipv4_address):
-            self.charm.unit.status = BlockedStatus("Invalid MME IPv4 address.")
             raise AddressValueError("Invalid MME IPv4 address.")
         relation = self.model.get_relation(self.relationship_name)
         relation.data[self.charm.app].update({"mme_ipv4_address": mme_ipv4_address})  # type: ignore[union-attr]  # noqa: E501

--- a/tests/unit/charms/lte_core_interface/v0/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/lte_core_interface/v0/dummy_provider_charm/src/charm.py
@@ -2,12 +2,10 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from ipaddress import AddressValueError
 
 from charms.lte_core_interface.v0.lte_core_interface import LTECoreProvides
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
-from ops.model import BlockedStatus
 
 
 class DummyLTECoreProviderCharm(CharmBase):
@@ -20,10 +18,7 @@ class DummyLTECoreProviderCharm(CharmBase):
     def _on_lte_core_relation_joined(self, event: RelationJoinedEvent) -> None:
         if not self.unit.is_leader():
             return
-        try:
-            self.lte_core_provider.set_lte_core_information(mme_ipv4_address="0.0.0.0")
-        except AddressValueError:
-            self.unit.status = BlockedStatus("Invalid MME IPv4 address.")
+        self.lte_core_provider.set_lte_core_information(mme_ipv4_address="0.0.0.0")
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/lte_core_interface/v0/dummy_provider_charm/src/charm.py
+++ b/tests/unit/charms/lte_core_interface/v0/dummy_provider_charm/src/charm.py
@@ -2,10 +2,12 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from ipaddress import AddressValueError
 
 from charms.lte_core_interface.v0.lte_core_interface import LTECoreProvides
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
+from ops.model import BlockedStatus
 
 
 class DummyLTECoreProviderCharm(CharmBase):
@@ -18,7 +20,10 @@ class DummyLTECoreProviderCharm(CharmBase):
     def _on_lte_core_relation_joined(self, event: RelationJoinedEvent) -> None:
         if not self.unit.is_leader():
             return
-        self.lte_core_provider.set_lte_core_information(mme_ipv4_address="0.0.0.0")
+        try:
+            self.lte_core_provider.set_lte_core_information(mme_ipv4_address="0.0.0.0")
+        except AddressValueError:
+            self.unit.status = BlockedStatus("Invalid MME IPv4 address.")
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/lte_core_interface/v0/dummy_requirer_charm/src/charm.py
+++ b/tests/unit/charms/lte_core_interface/v0/dummy_requirer_charm/src/charm.py
@@ -25,8 +25,9 @@ class DummyLTECoreRequirerCharm(CharmBase):
             self._on_lte_core_available,
         )
 
-    def _on_lte_core_available(self, event: LTECoreAvailableEvent):
-        pass
+    def _on_lte_core_available(self, event: LTECoreAvailableEvent) -> None:
+        mme_ipv4_address = event.mme_ipv4_address  # noqa: F841
+        # Here must be the code which uses the mme_ipv4_address
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_provider.py
+++ b/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_provider.py
@@ -4,11 +4,9 @@
 
 import unittest
 from ipaddress import AddressValueError
-from unittest.mock import Mock, patch
 
 import pytest
 from ops import testing
-from ops.model import BlockedStatus
 
 from tests.unit.charms.lte_core_interface.v0.dummy_provider_charm.src.charm import (
     DummyLTECoreProviderCharm,
@@ -75,20 +73,16 @@ class TestCoreProvider(unittest.TestCase):
 
         self.assertEqual(str(e.value), "Invalid MME IPv4 address.")
 
-    @patch(
-        "charms.lte_core_interface.v0.lte_core_interface.LTECoreProvides.set_lte_core_information"
-    )
-    def test_given_mme_address_is_not_valid_when_update_relation_data_then_status_is_blocked(  # noqa: E501
-        self, patch_set_lte_core_information
+    def test_given_not_valid_mme_ipv4_address_when_set_lte_core_information_then_value_error_is_raised(  # noqa: E501
+        self,
     ):
         self.harness.set_leader(is_leader=True)
-        patch_set_lte_core_information.side_effect = AddressValueError("Invalid MME IPv4 address.")
+        mme_ipv4_address = "invalid ipv4 address"
         self.harness.add_relation(
             relation_name=self.relation_name, remote_app=self.remote_app_name
         )
-        relation_joined_event = Mock()
-        self.harness.charm._on_lte_core_relation_joined(relation_joined_event)
 
-        self.assertEqual(
-            self.harness.charm.unit.status, BlockedStatus("Invalid MME IPv4 address.")
-        )
+        with pytest.raises(AddressValueError):
+            self.harness.charm.lte_core_provider.set_lte_core_information(
+                mme_ipv4_address=mme_ipv4_address
+            )

--- a/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_requirer.py
+++ b/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_requirer.py
@@ -23,9 +23,34 @@ class TestLTECoreRequirer(unittest.TestCase):
         self.harness = testing.Harness(DummyLTECoreRequirerCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.maxDiff = None
 
     @patch(f"{BASE_CHARM_PATH}._on_lte_core_available")
-    def test_given_lte_core_information_not_in_relation_data_when_relation_changed_then_on_lte_core_available_not_called(  # noqa: E501
+    def test_given_lte_core_information_in_relation_data_is_empty_when_relation_changed_then_on_lte_core_available_not_called(  # noqa: E501
+        self, patch_on_lte_core_available
+    ):
+        mme_ipv4_address = ""
+        relation_id = self.harness.add_relation(self.relation_name, remote_app=self.remote_app)
+        remote_app_relation_data = {"mme_ipv4_address": mme_ipv4_address}
+        expected_log = "Provider relation data did not pass JSON schema validation."  # noqa: E501
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.remote_app,
+            key_values=remote_app_relation_data,
+        )
+        with self.assertLogs() as captured:
+            self.harness.update_relation_data(
+                relation_id=relation_id,
+                app_or_unit=self.remote_app,
+                key_values=remote_app_relation_data,
+            )
+            self.assertEqual(expected_log, captured.records[0].getMessage())
+
+        patch_on_lte_core_available.assert_not_called()
+
+    @patch(f"{BASE_CHARM_PATH}._on_lte_core_available")
+    def test_given_valid_lte_core_information_in_relation_data_when_relation_changed_then_lte_core_available_event_is_emitted(  # noqa: E501
         self, patch_on_lte_core_available
     ):
         mme_ipv4_address = "0.0.0.0"
@@ -39,9 +64,6 @@ class TestLTECoreRequirer(unittest.TestCase):
         )
 
         patch_on_lte_core_available.assert_called()
-        args, _ = patch_on_lte_core_available.call_args
-        lte_core_available_event = args[0]
-        self.assertEqual(lte_core_available_event.mme_ipv4_address, mme_ipv4_address)
 
     @patch(f"{BASE_CHARM_PATH}._on_lte_core_available")
     def test_given_lte_core_information_not_in_relation_data_when_relation_changed_then_core_available_event_not_emitted(  # noqa: E501
@@ -53,3 +75,22 @@ class TestLTECoreRequirer(unittest.TestCase):
         )
 
         patch_on_lte_core_available.assert_not_called()
+
+    @patch(f"{BASE_CHARM_PATH}._on_lte_core_available")
+    def test_given_valid_lte_core_information_in_relation_data_when_relation_changed_then_lte_core_available_event_has_the_correct_info(  # noqa: E501
+        self, patch_on_lte_core_available
+    ):
+        mme_ipv4_address = "0.0.0.0"
+        relation_id = self.harness.add_relation(self.relation_name, remote_app=self.remote_app)
+        remote_app_relation_data = {"mme_ipv4_address": mme_ipv4_address}
+
+        self.harness.update_relation_data(
+            relation_id=relation_id,
+            app_or_unit=self.remote_app,
+            key_values=remote_app_relation_data,
+        )
+
+        args, _ = patch_on_lte_core_available.call_args
+        lte_core_available_event = args[0]
+        self.assertEqual(lte_core_available_event.mme_ipv4_address, mme_ipv4_address)
+

--- a/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_requirer.py
+++ b/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_requirer.py
@@ -93,4 +93,3 @@ class TestLTECoreRequirer(unittest.TestCase):
         args, _ = patch_on_lte_core_available.call_args
         lte_core_available_event = args[0]
         self.assertEqual(lte_core_available_event.mme_ipv4_address, mme_ipv4_address)
-

--- a/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_requirer.py
+++ b/tests/unit/charms/lte_core_interface/v0/test_lte_core_interface_requirer.py
@@ -34,11 +34,6 @@ class TestLTECoreRequirer(unittest.TestCase):
         remote_app_relation_data = {"mme_ipv4_address": mme_ipv4_address}
         expected_log = "Provider relation data did not pass JSON schema validation."  # noqa: E501
 
-        self.harness.update_relation_data(
-            relation_id=relation_id,
-            app_or_unit=self.remote_app,
-            key_values=remote_app_relation_data,
-        )
         with self.assertLogs() as captured:
             self.harness.update_relation_data(
                 relation_id=relation_id,


### PR DESCRIPTION
# Description

This PR addresses two issues regarding relation data validation:
1. The `validate()` method doesn't check the format of the ipv4 address. This is because the field is just informative and it's not supposed to do so. As said in the documentation:
>" `format` is just an annotation and does not effect validation."

More information [here](https://json-schema.org/understanding-json-schema/reference/string.html#format).

3. Previously if the provider places a non-ipv4 address in the relation data, the charm operator won't know about it. Now, it sets the provider to `BlockedStatus`.
# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules